### PR TITLE
Bump version to 0.5.1 and update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@logismika/crypto",
-  "version": "0.5.0-a4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@logismika/crypto",
-      "version": "0.5.0-a4.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.32.0"
@@ -18,8 +18,12 @@
         "@types/ramda": "^0.31.1",
         "chai": "^6.2.2",
         "mocha": "^11.7.5",
+        "serialize-javascript": ">=7.0.3",
         "ts-node": "^10.9.2",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -799,6 +803,16 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/mocha/node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -955,13 +969,13 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mocha": "^11.7.5",
     "ts-node": "^10.9.2",
     "typescript": "^5",
-    "serialize-javascript": ">=7.0.3"
+    "serialize-javascript": "^7.0.3"
   },
   "engines": {
     "node": ">=18.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logismika/crypto",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",
@@ -25,7 +25,8 @@
     "chai": "^6.2.2",
     "mocha": "^11.7.5",
     "ts-node": "^10.9.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "serialize-javascript": ">=7.0.3"
   },
   "engines": {
     "node": ">=18.18.0"


### PR DESCRIPTION
Bump package version to 0.5.1 in package.json and package-lock.json. Add serialize-javascript (>=7.0.3) as a dev dependency and update lockfile entries: top-level serialize-javascript updated to 7.0.4 (engines: node >=20.0.0) while mocha keeps a nested serialize-javascript@6.0.2. Also record Node engine constraint in the lockfile package metadata (node >=18.18.0).